### PR TITLE
#patch rename the configuration in the launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,39 +1,39 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/EngineBay.CommunityEdition/bin/Debug/net7.0/EngineBay.CommunityEdition.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/EngineBay.CommunityEdition",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://localhost:5050",
-                "DATABASE_RESET": "true",
-                "DATABASE_RESEED": "true",
-                "DATABASE_PROVIDER": "SQLite",
-                "AUTHENTICATION_METHOD": "Basic",
-                "AUTHENTICATION_AUDIENCE": "http://localhost:5050",
-                "AUTHENTICATION_ISSUER": "http://localhost:5050",
-                "AUTHENTICATION_VALIDATE_ISSUER_SIGNING_KEY": "false",
-                "API_DOCUMENTATION_ENABLED": "true",
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (engine bay commmunity edition api)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/EngineBay.CommunityEdition/bin/Debug/net7.0/EngineBay.CommunityEdition.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/EngineBay.CommunityEdition",
+      "stopAtEntry": false,
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:5050",
+        "DATABASE_RESET": "true",
+        "DATABASE_RESEED": "true",
+        "DATABASE_PROVIDER": "SQLite",
+        "AUTHENTICATION_METHOD": "Basic",
+        "AUTHENTICATION_AUDIENCE": "http://localhost:5050",
+        "AUTHENTICATION_ISSUER": "http://localhost:5050",
+        "AUTHENTICATION_VALIDATE_ISSUER_SIGNING_KEY": "false",
+        "API_DOCUMENTATION_ENABLED": "true",
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
 }


### PR DESCRIPTION
Renaming the configuration in the launch.json so it can be uniquely referenced from the dev-harness launch.json